### PR TITLE
Fix outputting all values to stdout

### DIFF
--- a/custom_components/starlink/__init__.py
+++ b/custom_components/starlink/__init__.py
@@ -156,7 +156,7 @@ class StarlinkClass:
         obj.target = None
         obj.numeric = False
         obj.loop_interval = 0.0
-        obj.verbose = False,
+        obj.verbose = True
         obj.samples = -1
         obj.poll_loops = 1
         obj.no_counter = False

--- a/custom_components/starlink/dish_grpc_text.py
+++ b/custom_components/starlink/dish_grpc_text.py
@@ -243,17 +243,17 @@ class DishGrpcText:
                                                             add_bulk=cb_add_bulk,
                                                             flush_history=shutdown)
 
-        if opts.verbose:
-            if csv_data:
-                print("\n".join(csv_data), file=print_file)
-                if opts.loop_interval > 0.0:
-                    print(file=print_file)
-        else:
-            if csv_data:
-                timestamp = status_ts if status_ts is not None else hist_ts
-                csv_data.insert(0, datetime.utcfromtimestamp(
-                    timestamp).isoformat())
-                print(",".join(csv_data), file=print_file)
+        #if opts.verbose:
+        #    if csv_data:
+        #        print("\n".join(csv_data), file=print_file)
+        #        if opts.loop_interval > 0.0:
+        #            print(file=print_file)
+        #else:
+        #    if csv_data:
+        #        timestamp = status_ts if status_ts is not None else hist_ts
+        #        csv_data.insert(0, datetime.utcfromtimestamp(
+        #            timestamp).isoformat())
+        #        print(",".join(csv_data), file=print_file)
 
         return ",".join(csv_data)
 


### PR DESCRIPTION
- Fix the confusing "opts.verbose = False," setting the option to be a tuple instead of actual False value.
- We actually depend on the == True behavior--using : as a key/value separator. However, we don't want to print that output to stdout. Unfortunately I think the simplest solution is to modify dish_grpc_text.py directly.